### PR TITLE
Adding python 3.13 compatibility flag

### DIFF
--- a/recordedfuturesandbox.json
+++ b/recordedfuturesandbox.json
@@ -14,7 +14,7 @@
     "product_vendor": "Recorded Future",
     "logo": "logo_recordedfuturesandbox.svg",
     "logo_dark": "logo_recordedfuturesandbox_dark.svg",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": false,
     "configuration": {
         "server": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Added support for Python 3.13


### PR DESCRIPTION

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

### Other information
- Added python 3.13 support
- Validated 3.13 by running all action in Splunk SOAR v 7.1.0
---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
